### PR TITLE
Fixes: WARNING: Could not execute identify to calculate DPI

### DIFF
--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -143,7 +143,7 @@ class PyGs(object):
         self.greyscale = greyscale
 
         # Now, run imagemagick identify to get pdf width/height/density
-        cmd = 'identify -format "%%w %%x %%h %%y\n" "%s"' % pdf_filename
+        cmd = 'identify -format "%%w %%x %%h %%y\\n" "%s"' % pdf_filename
         try:
             out = subprocess.check_output(cmd, shell=True)
             results = out.splitlines()[0]


### PR DESCRIPTION
Output:
````
identify -format "%w %x %h %y
" "example.pdf"

list index out of range
WARNING: Could not execute identify to calculate DPI (try installing imagemagick?), so defaulting to 300dpi
````