### PR TITLE
Python 3 compatibility (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
+before-install:
+    - sudo apt -qq update
+    - sudo apt install -y tesseract-ocr ghostscript imagemagick
 install: 
     - "pip install -r requirements.txt"
     - "pip install pytest mock"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
     - "3.5"
     - "3.6"
 before-install:
-    - sudo apt -qq update
-    - sudo apt install -y tesseract-ocr ghostscript imagemagick
+    - sudo apt-get -qq update
+    - sudo apt-get install -y tesseract-ocr ghostscript imagemagick
 install: 
     - "pip install -r requirements.txt"
     - "pip install pytest mock"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 install: 
     - "pip install -r requirements.txt --use-mirrors"
     - "pip install pytest mock --use-mirrors"
     - "pip install ."
 script: 
-    - "python setup.py test"
+    - "pytest test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-before-install:
+before_install:
     - sudo apt-get -qq update
     - sudo apt-get install -y tesseract-ocr ghostscript imagemagick
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
     - "3.5"
     - "3.6"
 install: 
-    - "pip install -r requirements.txt --use-mirrors"
-    - "pip install pytest mock --use-mirrors"
+    - "pip install -r requirements.txt"
+    - "pip install pytest mock"
     - "pip install ."
 script: 
     - "pytest test"

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -381,11 +381,11 @@ class PyPDFOCR(object):
             time.sleep(1)
             if not self.debug:
                 # Need to clean up the original image files before preprocessing
-                if locals().has_key("fns"): # Have to check if this was set before exception raised
+                if "fns" in locals(): # Have to check if this was set before exception raised
                     logging.info("Cleaning up %s" % fns)
                     self._clean_up_files(fns)
 
-                if locals().has_key("preprocess_imagefilenames"):  # Have to check if this was set before exception raised
+                if "preprocess_imagefilenames" in locals():  # Have to check if this was set before exception raised
                     logging.info("Cleaning up %s" % preprocess_imagefilenames)
                     self._clean_up_files(preprocess_imagefilenames) # splat the hocr_filenames as it is a list of pairs
                     for ext in [".hocr", ".html", ".txt"]:

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -61,12 +61,14 @@ def retry(count=5, exc_type = Exception):
     def decorator(func):
         @wraps(func)
         def result(*args, **kwargs):
+            err = None
             for _ in range(count):
                 try:
                     return func(*args, **kwargs)
-                except exc_type:
-                    pass
-                raise
+                except exc_type as e:
+                    err = e
+            else:
+                raise err
         return result
     return decorator
 
@@ -173,7 +175,7 @@ class PyPDFOCR(object):
         filing_group = p.add_argument_group(title="Filing optinos")
         filing_group.add_argument('-f', '--file', action='store_true',
             default=False, dest='enable_filing', help='Enable filing of converted PDFs')
-        #filing_group.add_argument('-c', '--config', type = argparse.FileType('r'),
+        # filing_group.add_argument('-c', '--config', type = argparse.FileType('r'),
         filing_group.add_argument('-c', '--config', type = lambda x: open_file_with_timeout(p,x),
              dest='configfile', help='Configuration file for defaults and PDF filing')
         filing_group.add_argument('-e', '--evernote', action='store_true',

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -467,7 +467,7 @@ class PyPDFOCR(object):
                 except KeyboardInterrupt:
                     break
                 except Exception as e:
-                    print traceback.print_exc(e)
+                    print(traceback.print_exc(e))
                     py_watcher.stop()
                     
         else:

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -49,6 +49,7 @@ from .pypdfocr_gs import PyGs
 from .pypdfocr_watcher import PyPdfWatcher
 from .pypdfocr_pdffiler import PyPdfFiler
 from .pypdfocr_filer_dirs import PyFilerDirs
+from .pypdfocr_filer_evernote import ENABLED as evernote_enabled
 from .pypdfocr_filer_evernote import PyFilerEvernote
 from .pypdfocr_preprocess import PyPreprocess
 
@@ -179,7 +180,7 @@ class PyPDFOCR(object):
         filing_group.add_argument('-c', '--config', type = lambda x: open_file_with_timeout(p,x),
              dest='configfile', help='Configuration file for defaults and PDF filing')
         filing_group.add_argument('-e', '--evernote', action='store_true',
-            default=False, dest='enable_evernote', help='Enable filing to Evernote')
+            default=False, dest='enable_evernote', help='Enable filing to Evernote.')
         filing_group.add_argument('-n', action='store_true',
             default=False, dest='match_using_filename', help='Use filename to match if contents did not match anything, before filing to default folder')
 
@@ -218,7 +219,11 @@ class PyPDFOCR(object):
             logging.debug("Read in configuration file")
             logging.debug(self.config)
 
-        if args.enable_evernote:
+        # Evernote filing does not work in py3
+        if args.enable_evernote and not evernote_enabled:
+            print("Warning: Evernote filing disabled, could not find evernote API. Evernote not available in py3.")
+            self.enable_evernote = False
+        elif args.enable_evernote:
             self.enable_evernote = True
         else:
             self.enable_evernote = False

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -21,7 +21,7 @@ import shutil, glob
 import itertools
 from functools import wraps
 
-from pypdfocr.version import __version__
+from .version import __version__
 from PIL import Image
 import yaml
 
@@ -40,17 +40,17 @@ try:
 except ImportError:
     import multiprocessing.forking as forking
 
-from pypdfocr.pypdfocr_multiprocessing import _Popen
+from .pypdfocr_multiprocessing import _Popen
 forking.Popen = _Popen
 
-from pypdfocr.pypdfocr_pdf import PyPdf
-from pypdfocr.pypdfocr_tesseract import PyTesseract
-from pypdfocr.pypdfocr_gs import PyGs
-from pypdfocr.pypdfocr_watcher import PyPdfWatcher
-from pypdfocr.pypdfocr_pdffiler import PyPdfFiler
-from pypdfocr.pypdfocr_filer_dirs import PyFilerDirs
-from pypdfocr.pypdfocr_filer_evernote import PyFilerEvernote
-from pypdfocr.pypdfocr_preprocess import PyPreprocess
+from .pypdfocr_pdf import PyPdf
+from .pypdfocr_tesseract import PyTesseract
+from .pypdfocr_gs import PyGs
+from .pypdfocr_watcher import PyPdfWatcher
+from .pypdfocr_pdffiler import PyPdfFiler
+from .pypdfocr_filer_dirs import PyFilerDirs
+from .pypdfocr_filer_evernote import PyFilerEvernote
+from .pypdfocr_preprocess import PyPreprocess
 
 def error(text):
     print("ERROR: %s" % text)

--- a/pypdfocr/pypdfocr.py
+++ b/pypdfocr/pypdfocr.py
@@ -21,24 +21,36 @@ import shutil, glob
 import itertools
 from functools import wraps
 
-from version import __version__
+from pypdfocr.version import __version__
 from PIL import Image
 import yaml
 
 import multiprocessing
-# Replace the Popen routine to allow win32 pyinstaller to build
-from multiprocessing import forking
-from pypdfocr_multiprocessing import _Popen
+
+""" Special work-around to support multiprocessing and pyinstaller --onefile on windows systms
+
+    https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing
+"""
+try:
+    # Python 3.4+
+    if sys.platform.startswith('win'):
+        import multiprocessing.popen_spawn_win32 as forking
+    else:
+        import multiprocessing.popen_fork as forking
+except ImportError:
+    import multiprocessing.forking as forking
+
+from pypdfocr.pypdfocr_multiprocessing import _Popen
 forking.Popen = _Popen
 
-from pypdfocr_pdf import PyPdf
-from pypdfocr_tesseract import PyTesseract
-from pypdfocr_gs import PyGs
-from pypdfocr_watcher import PyPdfWatcher
-from pypdfocr_pdffiler import PyPdfFiler
-from pypdfocr_filer_dirs import PyFilerDirs
-from pypdfocr_filer_evernote import PyFilerEvernote
-from pypdfocr_preprocess import PyPreprocess
+from pypdfocr.pypdfocr_pdf import PyPdf
+from pypdfocr.pypdfocr_tesseract import PyTesseract
+from pypdfocr.pypdfocr_gs import PyGs
+from pypdfocr.pypdfocr_watcher import PyPdfWatcher
+from pypdfocr.pypdfocr_pdffiler import PyPdfFiler
+from pypdfocr.pypdfocr_filer_dirs import PyFilerDirs
+from pypdfocr.pypdfocr_filer_evernote import PyFilerEvernote
+from pypdfocr.pypdfocr_preprocess import PyPreprocess
 
 def error(text):
     print("ERROR: %s" % text)

--- a/pypdfocr/pypdfocr_filer_dirs.py
+++ b/pypdfocr/pypdfocr_filer_dirs.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 
-from pypdfocr_filer import PyFiler
+from pypdfocr.pypdfocr_filer import PyFiler
 
 """
     Implementation of a filer class 

--- a/pypdfocr/pypdfocr_filer_dirs.py
+++ b/pypdfocr/pypdfocr_filer_dirs.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 
-from pypdfocr.pypdfocr_filer import PyFiler
+from .pypdfocr_filer import PyFiler
 
 """
     Implementation of a filer class 

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -23,13 +23,13 @@ from pypdfocr.pypdfocr_filer import PyFiler
 
 import functools
 
-from evernote.api.client import EvernoteClient
-import evernote.edam.type.ttypes as Types
-import evernote.edam.userstore.constants as UserStoreConstants
-from evernote.edam.error.ttypes import EDAMUserException
-from evernote.edam.error.ttypes import EDAMSystemException
-from evernote.edam.error.ttypes import EDAMNotFoundException
-from evernote.edam.error.ttypes import EDAMErrorCode
+# from evernote.api.client import EvernoteClient
+# import evernote.edam.type.ttypes as Types
+# import evernote.edam.userstore.constants as UserStoreConstants
+# from evernote.edam.error.ttypes import EDAMUserException
+# from evernote.edam.error.ttypes import EDAMSystemException
+# from evernote.edam.error.ttypes import EDAMNotFoundException
+# from evernote.edam.error.ttypes import EDAMErrorCode
 
 
 """

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -19,7 +19,7 @@ import hashlib
 import time
 import sys
 
-from pypdfocr.pypdfocr_filer import PyFiler
+from .pypdfocr_filer import PyFiler
 
 import functools
 

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -19,7 +19,7 @@ import hashlib
 import time
 import sys
 
-from pypdfocr_filer import PyFiler
+from pypdfocr.pypdfocr_filer import PyFiler
 
 import functools
 

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -23,13 +23,17 @@ from .pypdfocr_filer import PyFiler
 
 import functools
 
-# from evernote.api.client import EvernoteClient
-# import evernote.edam.type.ttypes as Types
-# import evernote.edam.userstore.constants as UserStoreConstants
-# from evernote.edam.error.ttypes import EDAMUserException
-# from evernote.edam.error.ttypes import EDAMSystemException
-# from evernote.edam.error.ttypes import EDAMNotFoundException
-# from evernote.edam.error.ttypes import EDAMErrorCode
+try:
+    from evernote.api.client import EvernoteClient
+    import evernote.edam.type.ttypes as Types
+    import evernote.edam.userstore.constants as UserStoreConstants
+    from evernote.edam.error.ttypes import EDAMUserException
+    from evernote.edam.error.ttypes import EDAMSystemException
+    from evernote.edam.error.ttypes import EDAMNotFoundException
+    from evernote.edam.error.ttypes import EDAMErrorCode
+    ENABLED = True
+except ImportError:
+    ENABLED = False
 
 
 """

--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -92,21 +92,21 @@ class PyGs(object):
             listing = os.listdir('.')
 
             # Find all possible gs* sub-directories
-	    listing = [x for x in listing if x.startswith('gs')]
+            listing = [x for x in listing if x.startswith('gs')]
 
             # TODO: Make this a natural sort
             listing.sort(reverse=True)
-	    for bindir in listing:
-		binpath = os.path.join(bindir,'bin')
-		if not os.path.exists(binpath): continue
-		os.chdir(binpath)
+            for bindir in listing:
+                binpath = os.path.join(bindir,'bin')
+                if not os.path.exists(binpath): continue
+                os.chdir(binpath)
                 # Look for gswin64c.exe or gswin32c.exe (the c is for the command-line version)
-		gswin = glob.glob('gswin*c.exe')
-		if len(gswin) == 0:
-		    continue
-		gs = os.path.abspath(gswin[0]) # Just use the first found .exe (Do i need to do anything more complicated here?)
-		os.chdir(cwd)
-		return gs
+                gswin = glob.glob('gswin*c.exe')
+                if len(gswin) == 0:
+                    continue
+                gs = os.path.abspath(gswin[0]) # Just use the first found .exe (Do i need to do anything more complicated here?)
+                os.chdir(cwd)
+                return gs
 
         if not gs:
             error(self.msgs['GS_MISSING_BINARY'])

--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -171,7 +171,7 @@ class PyGs(object):
         try:
             cmd = '%s -q -dNOPAUSE %s -sOutputFile="%s" "%s" -c quit' % (self.binary, options, output_filename, pdf_filename)
             logging.info(cmd)        
-            out = subprocess.check_output(cmd, shell=True)
+            out = subprocess.check_output(cmd, shell=True, universal_newlines=True)
 
         except subprocess.CalledProcessError as e:
             print(e.output)

--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -174,7 +174,7 @@ class PyGs(object):
             out = subprocess.check_output(cmd, shell=True)
 
         except subprocess.CalledProcessError as e:
-            print e.output
+            print(e.output)
             if "undefined in .getdeviceparams" in e.output:
                 error(self.msgs['GS_OUTDATED'])
             else:

--- a/pypdfocr/pypdfocr_multiprocessing.py
+++ b/pypdfocr/pypdfocr_multiprocessing.py
@@ -13,19 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, multiprocessing.forking
 import logging
+import os
+import sys
 
 """ Special work-around to support multiprocessing and pyinstaller --onefile on windows systms
 
     https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing
 """
+try:
+    # Python 3.4+
+    if sys.platform.startswith('win'):
+        import multiprocessing.popen_spawn_win32 as forking
+    else:
+        import multiprocessing.popen_fork as forking
+except ImportError:
+    import multiprocessing.forking as forking
 
-import multiprocessing.forking as forking
-import os
-import sys
 
-class _Popen(multiprocessing.forking.Popen):
+class _Popen(forking.Popen):
     def __init__(self, *args, **kw):
         if hasattr(sys, 'frozen'):
             # We have to set original _MEIPASS2 value from sys._MEIPASS

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -151,7 +151,8 @@ class PyPdf(object):
         all_text_filename = os.path.join(pdf_dir, "%s_text.pdf" % (basename))
         merger = PdfFileMerger()
         for text_pdf_filename in text_pdf_filenames:
-            merger.append(PdfFileReader(file(text_pdf_filename, 'rb')))
+            with open(text_pdf_filename, 'rb') as f:
+                merger.append(PdfFileReader(f))
         merger.write(all_text_filename)
         merger.close()
         del merger

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -155,7 +155,7 @@ class PyPdf(object):
             merger.append(PdfFileReader(file(text_pdf_filename, 'rb')))
         merger.write(all_text_filename)
         merger.close()
-	del merger
+        del merger
 
 
         writer = PdfFileWriter()

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -52,7 +52,7 @@ from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT
 from reportlab.platypus.paragraph import Paragraph
 
-from pypdfocr_util import Retry
+from pypdfocr.pypdfocr_util import Retry
 from functools import partial
 
 class RotatedPara(Paragraph):

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -31,7 +31,6 @@ import time
 import tempfile
 import glob
 
-import cStringIO
 import base64
 import zlib
 import math

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -51,7 +51,7 @@ from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT
 from reportlab.platypus.paragraph import Paragraph
 
-from pypdfocr.pypdfocr_util import Retry
+from .pypdfocr_util import Retry
 from functools import partial
 
 class RotatedPara(Paragraph):

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -24,8 +24,8 @@ import logging
 import shutil
 
 from PyPDF2 import PdfFileReader
-from pypdfocr.pypdfocr_filer import PyFiler
-from pypdfocr.pypdfocr_filer_dirs import PyFilerDirs
+from .pypdfocr_filer import PyFiler
+from .pypdfocr_filer_dirs import PyFilerDirs
 
 class PyPdfFiler(object):
     def __init__(self, filer):

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -18,7 +18,6 @@
     on keywords
 """
 
-from sets import Set    
 import sys, os
 import re
 import logging

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -59,7 +59,7 @@ class PyPdfFiler(object):
         # No match found, so return 
         return None
 
-    def file_original (self, original_filename):
+    def file_original(self, original_filename):
         return self.filer.file_original(original_filename)
 
     def move_to_matching_folder(self, filename):
@@ -76,5 +76,5 @@ class PyPdfFiler(object):
 if __name__ == '__main__':
     p = PyPdfFiler(PyFilerDirs())
     for page_text in p.iter_pdf_page_text("scan_ocr.pdf"):
-        print (page_text)
+        print(page_text)
 

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -35,7 +35,7 @@ class PyPdfFiler(object):
 
         # Whether to fall back on filename for matching keywords against
         # if there is no match in the text
-        self.file_using_filename = False 
+        self.file_using_filename = False
 
     def iter_pdf_page_text(self, filename):
         self.filename = filename
@@ -43,7 +43,7 @@ class PyPdfFiler(object):
         logging.info("pdf scanner found %d pages in %s" % (reader.getNumPages(), filename))
         for pgnum in range(reader.getNumPages()):
             text = reader.getPage(pgnum).extractText()
-            text = text.encode('ascii', 'ignore')
+            # text = text.encode('ascii', 'ignore')
             text = text.replace('\n', ' ')
             yield text
 
@@ -55,7 +55,7 @@ class PyPdfFiler(object):
                 if s in searchText:
                     logging.info("Matched keyword '%s'" % s)
                     return folder
-        # No match found, so return 
+        # No match found, so return
         return None
 
     def file_original(self, original_filename):
@@ -71,7 +71,7 @@ class PyPdfFiler(object):
 
         tgt_file = self.filer.move_to_matching_folder(filename, tgt_folder)
         return tgt_file
-        
+
 if __name__ == '__main__':
     p = PyPdfFiler(PyFilerDirs())
     for page_text in p.iter_pdf_page_text("scan_ocr.pdf"):

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -25,8 +25,8 @@ import logging
 import shutil
 
 from PyPDF2 import PdfFileReader
-from pypdfocr_filer import PyFiler
-from pypdfocr_filer_dirs import PyFilerDirs
+from pypdfocr.pypdfocr_filer import PyFiler
+from pypdfocr.pypdfocr_filer_dirs import PyFilerDirs
 
 class PyPdfFiler(object):
     def __init__(self, filer):

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -58,7 +58,7 @@ class PyPreprocess(object):
             logging.debug(out)
             return out
         except subprocess.CalledProcessError as e:
-            print e.output
+            print(e.output)
             self._warn("Could not run command %s" % cmd_list)
             
 
@@ -102,14 +102,14 @@ class PyPreprocess(object):
             logging.info("Starting preprocessing parallel execution")
             preprocessed_filenames = pool.map(unwrap_self,zip([self]*len(fns),fns))
             pool.close()
-        except KeyboardInterrupt or Exception:
+        except (KeyboardInterrupt, Exception):
             print("Caught keyboard interrupt... terminating")
             pool.terminate()
             #sys,exit(-1)
             raise
         finally:
             pool.join()
-            logging.info ("Completed preprocessing")
+            logging.info("Completed preprocessing")
 
         return preprocessed_filenames
 

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -28,7 +28,7 @@ import functools
 import signal
 
 from multiprocessing import Pool
-from pypdfocr_interrupts import init_worker
+from pypdfocr.pypdfocr_interrupts import init_worker
 
 # Ugly hack to pass in object method to the multiprocessing library
 # From http://www.rueckstiess.net/research/snippets/show/ca1d7d90

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -28,7 +28,7 @@ import functools
 import signal
 
 from multiprocessing import Pool
-from pypdfocr.pypdfocr_interrupts import init_worker
+from .pypdfocr_interrupts import init_worker
 
 # Ugly hack to pass in object method to the multiprocessing library
 # From http://www.rueckstiess.net/research/snippets/show/ca1d7d90

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -26,7 +26,7 @@ import glob
 from subprocess import CalledProcessError
 
 from multiprocessing import Pool
-from pypdfocr_interrupts import init_worker
+from pypdfocr.pypdfocr_interrupts import init_worker
 
 def error(text):
     print("ERROR: %s" % text)

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -23,11 +23,11 @@ import os, sys
 import logging
 import subprocess
 import glob
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 from subprocess import CalledProcessError
 
 from multiprocessing import Pool
-from pypdfocr.pypdfocr_interrupts import init_worker
+from .pypdfocr_interrupts import init_worker
 
 def error(text):
     print("ERROR: %s" % text)
@@ -80,11 +80,11 @@ class PyTesseract(object):
             Make sure the version is current 
         """
         logging.info("Checking tesseract version")
-        cmd = '%s -v' % (self.binary)
+        cmd = [self.binary, '-v']
         logging.info(cmd)        
         try:
             ret_output = subprocess.check_output(
-                cmd, shell=True, encoding="utf-8", stderr=subprocess.STDOUT)
+                cmd, shell=True, stderr=subprocess.STDOUT)
         except CalledProcessError:
             # Could not run tesseract
             error(self.msgs['TS_MISSING'])
@@ -93,14 +93,12 @@ class PyTesseract(object):
         for line in ret_output.splitlines():
             if 'tesseract' in line:
                 ver_str = line.split(' ')[1]
-                if ver_str.endswith('dev'): # Fix for version strings that end in 'dev'
-                    ver_str = ver_str[:-3]
         # Aargh, in windows 3.02.02 is reported as version 3.02  
         if str(os.name) == 'nt':
             req = self.required[:-3]
         else:
             req = self.required
-        return (StrictVersion(ver_str) >= StrictVersion(req)), ver_str
+        return (parse_version(ver_str) >= parse_version(req)), ver_str
 
     def _warn(self, msg): # pragma: no cover
         print("WARNING: %s" % msg)

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -84,7 +84,7 @@ class PyTesseract(object):
         logging.info(cmd)        
         try:
             ret_output = subprocess.check_output(
-                cmd, shell=True, stderr=subprocess.STDOUT)
+                cmd, shell=True, stderr=subprocess.STDOUT, universal_newlines=True)
         except CalledProcessError:
             # Could not run tesseract
             error(self.msgs['TS_MISSING'])

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -80,7 +80,7 @@ class PyTesseract(object):
             Make sure the version is current 
         """
         logging.info("Checking tesseract version")
-        cmd = [self.binary, '-v']
+        cmd = "%s -v" % self.binary
         logging.info(cmd)        
         try:
             ret_output = subprocess.check_output(
@@ -91,6 +91,7 @@ class PyTesseract(object):
 
         ver_str = '0.0.0'
         for line in ret_output.splitlines():
+            print(line)
             if 'tesseract' in line:
                 ver_str = line.split(' ')[1]
         # Aargh, in windows 3.02.02 is reported as version 3.02  
@@ -98,6 +99,7 @@ class PyTesseract(object):
             req = self.required[:-3]
         else:
             req = self.required
+        print(ver_str)
         return (parse_version(ver_str) >= parse_version(req)), ver_str
 
     def _warn(self, msg): # pragma: no cover

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -166,7 +166,7 @@ class PyTesseract(object):
             ret_output = subprocess.check_output(cmd, shell=True,  stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             # Could not run tesseract
-            print e.output
+            print(e.output)
             self._warn (self.msgs['TS_FAILED'])
                 
         if os.path.isfile(hocr_filename):

--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -117,7 +117,7 @@ class PyTesseract(object):
         pool = Pool(processes=self.threads, initializer=init_worker)
 
         try:
-            hocr_filenames = pool.map(unwrap_self, zip([self]*len(fns), fns))
+            hocr_filenames = pool.map(unwrap_self, list(zip([self]*len(fns), fns)))
             pool.close()
         except (KeyboardInterrupt, Exception):
             print("Caught keyboard interrupt... terminating")
@@ -126,7 +126,7 @@ class PyTesseract(object):
         finally:
             pool.join()
 
-        return zip(fns,hocr_filenames)
+        return list(zip(fns,hocr_filenames))
 
 
     def make_hocr_from_pnm(self, img_filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pillow>=2.2
 reportlab>=2.7
 watchdog>=0.6.0
 pypdf2>=1.23
-# evernote
+evernote; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pillow>=2.2
 reportlab>=2.7
 watchdog>=0.6.0
 pypdf2>=1.23
-evernote
+# evernote

--- a/test/test_evernote.py
+++ b/test/test_evernote.py
@@ -1,123 +1,123 @@
-#from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_filer_evernote as P
-import pytest
-import os
+# #from pypdfocr import PyPDFOCR as P
+# import pypdfocr.pypdfocr_filer_evernote as P
+# import pytest
+# import os
 
-import evernote.api.client
-import evernote.edam.type.ttypes as Types
-import hashlib
+# import evernote.api.client
+# import evernote.edam.type.ttypes as Types
+# import hashlib
 
-from mock import patch, call
+# from mock import patch, call
 
-class TestEvernote:
+# class TestEvernote:
 
-    def test_connecct(self):
-        # Tricky mocking.  Need to mock the EvernoteClient import in pypdfocr_filer_evernote.py file
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-            inst = mock_evernote_client.return_value
-            assert(inst.get_user_store.called)
+#     def test_connecct(self):
+#         # Tricky mocking.  Need to mock the EvernoteClient import in pypdfocr_filer_evernote.py file
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+#             inst = mock_evernote_client.return_value
+#             assert(inst.get_user_store.called)
 
-    @patch('shutil.move')
-    def test_file_original(self, mock_move):
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-            filename = os.path.join("pdfs","test_recipe.pdf")
+#     @patch('shutil.move')
+#     def test_file_original(self, mock_move):
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+#             filename = os.path.join("pdfs","test_recipe.pdf")
 
-            # First, test code that does not move original
-            p.file_original(filename)
-            assert (not mock_move.called)
+#             # First, test code that does not move original
+#             p.file_original(filename)
+#             assert (not mock_move.called)
 
-            # Now test moving
-            p.set_original_move_folder(os.path.join("temp", "original"))
-            p.file_original(filename)
-            mock_move.assert_called_with(filename, os.path.join("temp","original", "test_recipe_2.pdf"))
+#             # Now test moving
+#             p.set_original_move_folder(os.path.join("temp", "original"))
+#             p.file_original(filename)
+#             mock_move.assert_called_with(filename, os.path.join("temp","original", "test_recipe_2.pdf"))
 
-    @patch('os.remove')
-    def test_move_to_folder(self, mock_remove):
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-	    filename = os.path.join("pdfs", "test_recipe.pdf")
-            foldername = 'recipe'
-            with pytest.raises(AssertionError):
-                p.move_to_matching_folder(filename, foldername)
-            p.set_target_folder('target')
-            with pytest.raises(AssertionError):
-                p.move_to_matching_folder(filename, foldername)
-            p.set_default_folder('default')
-            p.move_to_matching_folder(filename, None)
-            p.move_to_matching_folder(filename, foldername)
+#     @patch('os.remove')
+#     def test_move_to_folder(self, mock_remove):
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+# 	    filename = os.path.join("pdfs", "test_recipe.pdf")
+#             foldername = 'recipe'
+#             with pytest.raises(AssertionError):
+#                 p.move_to_matching_folder(filename, foldername)
+#             p.set_target_folder('target')
+#             with pytest.raises(AssertionError):
+#                 p.move_to_matching_folder(filename, foldername)
+#             p.set_default_folder('default')
+#             p.move_to_matching_folder(filename, None)
+#             p.move_to_matching_folder(filename, foldername)
             
-            mock_client = mock_evernote_client.return_value
-            assert(mock_client.get_note_store.called)
-            assert(mock_client.get_note_store.return_value.createNote.called)
-            mock_remove.assert_called_with(filename)
+#             mock_client = mock_evernote_client.return_value
+#             assert(mock_client.get_note_store.called)
+#             assert(mock_client.get_note_store.return_value.createNote.called)
+#             mock_remove.assert_called_with(filename)
 
-            
-
-
-    def test_create_note(self):
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-            notebook = Types.Notebook()
-            notebook.name = "recipe"
-            filename = "pdfs/test_recipe.pdf"
-            note = p._create_evernote_note(notebook, filename)
-            xml = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">'
-            assert(note.content.startswith(xml))
-
-            md5 = hashlib.md5()
-            with open(filename,'rb') as f: 
-                pdf_bytes = f.read()
-                md5.update(pdf_bytes)
-
-            md5hash = md5.hexdigest()
-            
-            assert(md5hash in note.content)
-            assert(note.resources[0].data.bodyHash == md5hash)
-
-
-    def test_check_notebook(self):
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-            p._check_and_make_notebook("new_notebook")
-            # Let's assert that we tried to create a new notebook
-            mock_client = mock_evernote_client.return_value
-            assert(mock_client.get_note_store.called)
-            create_func = mock_client.get_note_store.return_value.createNotebook
-            update_func = mock_client.get_note_store.return_value.updateNotebook
-            assert(create_func.called)
-            assert(not update_func.called)
-            notebook = create_func.call_args[0][0]
-            assert(notebook.name == 'new_notebook')
-
-            # Now, let's setup a value for the notebooks, so we test the code for
-            # a "pre-exisiting" notebook
-            test_notebook = Types.Notebook()
-            test_notebook.name = "new_notebook"
-            mock_client.get_note_store.return_value.listNotebooks.return_value = [test_notebook]
-            p._check_and_make_notebook("new_notebook")
-
-            # Now check that the code to update a notebook stack is correct
-            test_notebook.stack = "new_stack"
-            update_func = mock_client.get_note_store.return_value.updateNotebook
-            p.set_target_folder("Boogie")
-            p._check_and_make_notebook("new_notebook")
-            # Check that the update call was called with correct arguments
-            assert(update_func.called)
-            notebook = update_func.call_args[0][0]
-            assert(notebook.stack == 'Boogie')
             
 
-    def test_add_folder_target(self):
-        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-            p = P.PyFilerEvernote("TOKEN")
-            p.add_folder_target("folder1", ["target1", "target2"])
-            with pytest.raises(AssertionError):
-                p.add_folder_target("folder1", ["target1", "target2"])
-            p.add_folder_target("folder2", ["target1", "target2"])
-            assert("folder1" in p.folder_targets.keys())
-            assert("folder2" in p.folder_targets.keys())
+
+#     def test_create_note(self):
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+#             notebook = Types.Notebook()
+#             notebook.name = "recipe"
+#             filename = "pdfs/test_recipe.pdf"
+#             note = p._create_evernote_note(notebook, filename)
+#             xml = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">'
+#             assert(note.content.startswith(xml))
+
+#             md5 = hashlib.md5()
+#             with open(filename,'rb') as f: 
+#                 pdf_bytes = f.read()
+#                 md5.update(pdf_bytes)
+
+#             md5hash = md5.hexdigest()
+            
+#             assert(md5hash in note.content)
+#             assert(note.resources[0].data.bodyHash == md5hash)
+
+
+#     def test_check_notebook(self):
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+#             p._check_and_make_notebook("new_notebook")
+#             # Let's assert that we tried to create a new notebook
+#             mock_client = mock_evernote_client.return_value
+#             assert(mock_client.get_note_store.called)
+#             create_func = mock_client.get_note_store.return_value.createNotebook
+#             update_func = mock_client.get_note_store.return_value.updateNotebook
+#             assert(create_func.called)
+#             assert(not update_func.called)
+#             notebook = create_func.call_args[0][0]
+#             assert(notebook.name == 'new_notebook')
+
+#             # Now, let's setup a value for the notebooks, so we test the code for
+#             # a "pre-exisiting" notebook
+#             test_notebook = Types.Notebook()
+#             test_notebook.name = "new_notebook"
+#             mock_client.get_note_store.return_value.listNotebooks.return_value = [test_notebook]
+#             p._check_and_make_notebook("new_notebook")
+
+#             # Now check that the code to update a notebook stack is correct
+#             test_notebook.stack = "new_stack"
+#             update_func = mock_client.get_note_store.return_value.updateNotebook
+#             p.set_target_folder("Boogie")
+#             p._check_and_make_notebook("new_notebook")
+#             # Check that the update call was called with correct arguments
+#             assert(update_func.called)
+#             notebook = update_func.call_args[0][0]
+#             assert(notebook.stack == 'Boogie')
+            
+
+#     def test_add_folder_target(self):
+#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+#             p = P.PyFilerEvernote("TOKEN")
+#             p.add_folder_target("folder1", ["target1", "target2"])
+#             with pytest.raises(AssertionError):
+#                 p.add_folder_target("folder1", ["target1", "target2"])
+#             p.add_folder_target("folder2", ["target1", "target2"])
+#             assert("folder1" in p.folder_targets.keys())
+#             assert("folder2" in p.folder_targets.keys())
 
                     
     

--- a/test/test_evernote.py
+++ b/test/test_evernote.py
@@ -1,123 +1,137 @@
-# #from pypdfocr import PyPDFOCR as P
-# import pypdfocr.pypdfocr_filer_evernote as P
-# import pytest
-# import os
+#from pypdfocr import PyPDFOCR as P
+import pypdfocr.pypdfocr_filer_evernote as P
+import pytest
+import os
+import sys
 
-# import evernote.api.client
-# import evernote.edam.type.ttypes as Types
-# import hashlib
+if sys.version_info.major == 2:
+    import evernote.api.client
+    import evernote.edam.type.ttypes as Types
+import hashlib
 
-# from mock import patch, call
+from mock import patch, call
 
-# class TestEvernote:
 
-#     def test_connecct(self):
-#         # Tricky mocking.  Need to mock the EvernoteClient import in pypdfocr_filer_evernote.py file
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-#             inst = mock_evernote_client.return_value
-#             assert(inst.get_user_store.called)
+def test_import():
+    """Evernote filing enabled for py2 only"""
+    expect_enabled = sys.version_info.major == 2
+    assert P.ENABLED == expect_enabled
 
-#     @patch('shutil.move')
-#     def test_file_original(self, mock_move):
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-#             filename = os.path.join("pdfs","test_recipe.pdf")
 
-#             # First, test code that does not move original
-#             p.file_original(filename)
-#             assert (not mock_move.called)
+@pytest.mark.skipif(sys.version_info.major>=3, 
+                    reason="Evernote API not compatible with py3.")
+class TestEvernote:
 
-#             # Now test moving
-#             p.set_original_move_folder(os.path.join("temp", "original"))
-#             p.file_original(filename)
-#             mock_move.assert_called_with(filename, os.path.join("temp","original", "test_recipe_2.pdf"))
+    def test_connecct(self):
+        # Tricky mocking.  Need to mock the EvernoteClient import in pypdfocr_filer_evernote.py file
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            inst = mock_evernote_client.return_value
+            assert(inst.get_user_store.called)
 
-#     @patch('os.remove')
-#     def test_move_to_folder(self, mock_remove):
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-# 	    filename = os.path.join("pdfs", "test_recipe.pdf")
-#             foldername = 'recipe'
-#             with pytest.raises(AssertionError):
-#                 p.move_to_matching_folder(filename, foldername)
-#             p.set_target_folder('target')
-#             with pytest.raises(AssertionError):
-#                 p.move_to_matching_folder(filename, foldername)
-#             p.set_default_folder('default')
-#             p.move_to_matching_folder(filename, None)
-#             p.move_to_matching_folder(filename, foldername)
+    @patch('shutil.move')
+    def test_file_original(self, mock_move):
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            filepath = os.path.dirname(__file__)
+            filename = os.path.join(filepath, "pdfs","test_recipe.pdf")
+
+            # First, test code that does not move original
+            p.file_original(filename)
+            assert (not mock_move.called)
+
+            # Now test moving
+            p.set_original_move_folder(os.path.join(filepath, "temp", "original"))
+            p.file_original(filename)
+            mock_move.assert_called_with(filename, os.path.join(filepath, "temp","original", "test_recipe_2.pdf"))
+
+    @patch('os.remove')
+    def test_move_to_folder(self, mock_remove):
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            filepath = os.path.dirname(__file__)
+            filename = os.path.join(filepath, "pdfs", "test_recipe.pdf")
+            foldername = os.path.join(filepath, 'recipe')
+            with pytest.raises(AssertionError):
+                p.move_to_matching_folder(filename, foldername)
+            p.set_target_folder('target')
+            with pytest.raises(AssertionError):
+                p.move_to_matching_folder(filename, foldername)
+            p.set_default_folder('default')
+            p.move_to_matching_folder(filename, None)
+            p.move_to_matching_folder(filename, foldername)
             
-#             mock_client = mock_evernote_client.return_value
-#             assert(mock_client.get_note_store.called)
-#             assert(mock_client.get_note_store.return_value.createNote.called)
-#             mock_remove.assert_called_with(filename)
+            mock_client = mock_evernote_client.return_value
+            assert(mock_client.get_note_store.called)
+            assert(mock_client.get_note_store.return_value.createNote.called)
+            mock_remove.assert_called_with(filename)
 
-            
-
-
-#     def test_create_note(self):
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-#             notebook = Types.Notebook()
-#             notebook.name = "recipe"
-#             filename = "pdfs/test_recipe.pdf"
-#             note = p._create_evernote_note(notebook, filename)
-#             xml = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">'
-#             assert(note.content.startswith(xml))
-
-#             md5 = hashlib.md5()
-#             with open(filename,'rb') as f: 
-#                 pdf_bytes = f.read()
-#                 md5.update(pdf_bytes)
-
-#             md5hash = md5.hexdigest()
-            
-#             assert(md5hash in note.content)
-#             assert(note.resources[0].data.bodyHash == md5hash)
-
-
-#     def test_check_notebook(self):
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-#             p._check_and_make_notebook("new_notebook")
-#             # Let's assert that we tried to create a new notebook
-#             mock_client = mock_evernote_client.return_value
-#             assert(mock_client.get_note_store.called)
-#             create_func = mock_client.get_note_store.return_value.createNotebook
-#             update_func = mock_client.get_note_store.return_value.updateNotebook
-#             assert(create_func.called)
-#             assert(not update_func.called)
-#             notebook = create_func.call_args[0][0]
-#             assert(notebook.name == 'new_notebook')
-
-#             # Now, let's setup a value for the notebooks, so we test the code for
-#             # a "pre-exisiting" notebook
-#             test_notebook = Types.Notebook()
-#             test_notebook.name = "new_notebook"
-#             mock_client.get_note_store.return_value.listNotebooks.return_value = [test_notebook]
-#             p._check_and_make_notebook("new_notebook")
-
-#             # Now check that the code to update a notebook stack is correct
-#             test_notebook.stack = "new_stack"
-#             update_func = mock_client.get_note_store.return_value.updateNotebook
-#             p.set_target_folder("Boogie")
-#             p._check_and_make_notebook("new_notebook")
-#             # Check that the update call was called with correct arguments
-#             assert(update_func.called)
-#             notebook = update_func.call_args[0][0]
-#             assert(notebook.stack == 'Boogie')
             
 
-#     def test_add_folder_target(self):
-#         with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
-#             p = P.PyFilerEvernote("TOKEN")
-#             p.add_folder_target("folder1", ["target1", "target2"])
-#             with pytest.raises(AssertionError):
-#                 p.add_folder_target("folder1", ["target1", "target2"])
-#             p.add_folder_target("folder2", ["target1", "target2"])
-#             assert("folder1" in p.folder_targets.keys())
-#             assert("folder2" in p.folder_targets.keys())
+
+    def test_create_note(self):
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            notebook = Types.Notebook()
+            notebook.name = "recipe"
+            filepath = os.path.dirname(__file__)
+            filename = os.path.join(filepath, "pdfs/test_recipe.pdf")
+            note = p._create_evernote_note(notebook, filename)
+            xml = '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">'
+            assert(note.content.startswith(xml))
+
+            md5 = hashlib.md5()
+            with open(filename,'rb') as f: 
+                pdf_bytes = f.read()
+                md5.update(pdf_bytes)
+
+            md5hash = md5.hexdigest()
+            
+            assert(md5hash in note.content)
+            assert(note.resources[0].data.bodyHash == md5hash)
+
+
+    def test_check_notebook(self):
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            p._check_and_make_notebook("new_notebook")
+            # Let's assert that we tried to create a new notebook
+            mock_client = mock_evernote_client.return_value
+            assert(mock_client.get_note_store.called)
+            create_func = mock_client.get_note_store.return_value.createNotebook
+            update_func = mock_client.get_note_store.return_value.updateNotebook
+            assert(create_func.called)
+            assert(not update_func.called)
+            notebook = create_func.call_args[0][0]
+            assert(notebook.name == 'new_notebook')
+
+            # Now, let's setup a value for the notebooks, so we test the code for
+            # a "pre-exisiting" notebook
+            test_notebook = Types.Notebook()
+            test_notebook.name = "new_notebook"
+            mock_client.get_note_store.return_value.listNotebooks.return_value = [test_notebook]
+            p._check_and_make_notebook("new_notebook")
+
+            # Now check that the code to update a notebook stack is correct
+            test_notebook.stack = "new_stack"
+            update_func = mock_client.get_note_store.return_value.updateNotebook
+            p.set_target_folder("Boogie")
+            p._check_and_make_notebook("new_notebook")
+            # Check that the update call was called with correct arguments
+            assert(update_func.called)
+            notebook = update_func.call_args[0][0]
+            assert(notebook.stack == 'Boogie')
+            
+
+    def test_add_folder_target(self):
+        with patch("pypdfocr.pypdfocr_filer_evernote.EvernoteClient") as mock_evernote_client:
+            p = P.PyFilerEvernote("TOKEN")
+            p.add_folder_target("folder1", ["target1", "target2"])
+            with pytest.raises(AssertionError):
+                p.add_folder_target("folder1", ["target1", "target2"])
+            p.add_folder_target("folder2", ["target1", "target2"])
+            assert("folder1" in p.folder_targets.keys())
+            assert("folder2" in p.folder_targets.keys())
 
                     
     

--- a/test/test_gs.py
+++ b/test/test_gs.py
@@ -3,10 +3,7 @@ import pypdfocr.pypdfocr_gs as P
 import pytest
 import os
 
-import hashlib
-
-from mock import patch, call
-from pytest import skip
+from mock import patch
 
 class TestGS:
 

--- a/test/test_gs.py
+++ b/test/test_gs.py
@@ -1,5 +1,5 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_gs as P
+from pypdfocr import pypdfocr_gs as P
 import pytest
 import os
 

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from pypdfocr import pypdfocr as P
 import pytest
@@ -45,6 +46,8 @@ class TestOptions:
         assert(self.p.enable_filing)
         assert(self.p.config)
 
+    @pytest.mark.skipif(sys.version_info.major>2,
+                        reason="Evernote disabled for py3")
     def test_standalone_filing_evernote(self):
         # Check when evernote is enabled
         opts = ["blah.pdf"]
@@ -70,6 +73,23 @@ class TestOptions:
         assert(self.p.config)
         assert(not self.p.watch)
 
+    @pytest.mark.skipif(sys.version_info.major==2,
+                        reason="Evernote works on py2")
+    def test_evernote_disabled(self):
+        opts = ["blah.pdf"]
+        opts.append('-e')
+        # Assert that it checks that the config file is present
+        with pytest.raises(SystemExit):
+            self.p.get_options(opts)
+
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
+        self.p.get_options(opts)
+        # Enabling -e should turn on filing too
+        assert(self.p.enable_filing)
+        assert not self.p.enable_evernote
+
     def test_standalone_watch_conflict(self):
         # When pdf file is specified, we don't want to allow watch option
         opts = ["blah.pdf", '-w']
@@ -94,6 +114,8 @@ class TestOptions:
         assert(not self.p.enable_filing)
         assert(not self.p.enable_evernote)
 
+    @pytest.mark.skipif(sys.version_info.major>2,
+                        reason="Evernote disabled for py3")
     def test_watch_filing_evernote(self):
         conf_path = os.path.join(
             os.path.dirname(__file__), 'test_option_config.yaml')

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -1,6 +1,6 @@
 import os
 
-import pypdfocr.pypdfocr as P
+from pypdfocr import pypdfocr as P
 import pytest
 
 

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -86,8 +86,6 @@ class TestOptions:
             os.path.dirname(__file__), 'test_option_config.yaml')
         opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
-        # Enabling -e should turn on filing too
-        assert(self.p.enable_filing)
         assert not self.p.enable_evernote
 
     def test_standalone_watch_conflict(self):

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -1,4 +1,5 @@
-#from pypdfocr import PyPDFOCR as P
+import os
+
 import pypdfocr.pypdfocr as P
 import pytest
 
@@ -37,7 +38,9 @@ class TestOptions:
             self.p.get_options(opts)
 
         # Assert that it checks that the config file is present
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         assert(self.p.enable_filing)
         assert(self.p.config)
@@ -50,7 +53,9 @@ class TestOptions:
         with pytest.raises(SystemExit):
             self.p.get_options(opts)
 
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         # Enabling -e should turn on filing too
         assert(self.p.enable_filing)
@@ -80,8 +85,9 @@ class TestOptions:
         opts = ['-w temp']
         self.p.get_options(opts)
         assert(self.p.watch_dir)
-
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)
@@ -96,7 +102,10 @@ class TestOptions:
         assert(self.p.enable_filing)
         assert(self.p.enable_evernote)
 
-        opts = ['-w temp', '-f', '-e',  '--config=test_option_config.yaml']
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
+        opts = ['-w temp', '-f', '-e',  '--config={}'.format(conf_path)]
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -95,7 +95,9 @@ class TestOptions:
         assert(not self.p.enable_evernote)
 
     def test_watch_filing_evernote(self):
-        opts = ['-w temp', '-e', '--config=test_option_config.yaml']
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts = ['-w temp', '-e', '--config={}'.format(conf_path)]
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)
@@ -104,7 +106,6 @@ class TestOptions:
 
         conf_path = os.path.join(
             os.path.dirname(__file__), 'test_option_config.yaml')
-        opts.append('--config={}'.format(conf_path))
         opts = ['-w temp', '-f', '-e',  '--config={}'.format(conf_path)]
         self.p.get_options(opts)
         assert(self.p.watch)

--- a/test/test_pdf_filer.py
+++ b/test/test_pdf_filer.py
@@ -15,7 +15,9 @@ class TestPDFFiler:
         # Mock the move function so we don't actually end up filing
         p = P.PyPDFOCR()
         cwd = os.getcwd()
-        filename = os.path.join("pdfs", "test_super_long_keyword.pdf")
+        filename = os.path.join(os.path.dirname(__file__),
+                                "pdfs",
+                                "test_super_long_keyword.pdf")
         out_filename = filename.replace(".pdf", "_ocr.pdf")
 
         if os.path.exists(out_filename):
@@ -23,7 +25,10 @@ class TestPDFFiler:
 
         print("Current directory: %s" % os.getcwd())
         #opts = [filename, "--config=test_pypdfocr_config.yaml", "-f"]
-        opts = [filename, "--config=test_pypdfocr_config_filename.yaml", "-f", "-n"]
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_pypdfocr_config.yaml')
+
+        opts = [filename, "--config={}".format(conf_path), "-f", "-n"]
         p.go(opts)
 
         assert(os.path.exists(out_filename))
@@ -34,4 +39,4 @@ class TestPDFFiler:
 
 
 
-        
+

--- a/test/test_pdf_filer.py
+++ b/test/test_pdf_filer.py
@@ -1,12 +1,8 @@
 #from pypdfocr import PyPDFOCR as P
 import pypdfocr.pypdfocr as P
-import pytest
 import os
 
-import hashlib
-
 from mock import patch, call
-from pytest import skip
 
 class TestPDFFiler:
 

--- a/test/test_pdf_filer.py
+++ b/test/test_pdf_filer.py
@@ -1,5 +1,5 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr as P
+from pypdfocr import pypdfocr as P
 import os
 
 from mock import patch, call

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -26,22 +26,21 @@ class TestPydfocr:
     filepath = os.path.dirname(__file__)
     pdf_tests = [
         (
-            # Test the single file conversion with no filing.
             filepath,
             os.path.join(filepath, "temp","target","recipe"),
             os.path.join(filepath, "pdfs", "test_recipe.pdf"),
             [ ["Simply Recipes"],]),
         (
             filepath,
-            os.path.join("temp","target","patents"),
+            os.path.join(filepath, "temp","target","patents"),
             os.path.join("pdfs","test_patent.pdf"),
             [
                 ["asynchronous", "subject to", "20 Claims"], # Page 1
                 ["FOREIGN PATENT" ], # Page 2
-                ]),
+            ]),
         (
             filepath,
-            os.path.join("temp","target", "default"),
+            os.path.join(filepath, "temp","target", "default"),
             os.path.join("pdfs","test_sherlock.pdf"),
             [
                 ["Bohemia", "Trincomalee"], # Page 1
@@ -49,7 +48,7 @@ class TestPydfocr:
             ]),
         (
             os.path.join(filepath, "pdfs"),
-            os.path.join("temp","target","default"),
+            os.path.join(filepath, "temp","target","default"),
             "test_sherlock.pdf",
             [
                 ["Bohemia", "Trincomalee"], # Page 1
@@ -57,21 +56,21 @@ class TestPydfocr:
             ]),
         (
             filepath,
-            os.path.join("temp","target","recipe"),
+            os.path.join(filepath, "temp","target","recipe"),
             os.path.join("..","test", "pdfs", "1.pdf"),
             [
                 ["Simply","Recipes"],
             ]),
         (
             filepath,
-            os.path.join("temp","target","recipe"),
+            os.path.join(filepath, "temp","target","recipe"),
             os.path.join("..","test", "pdfs", "test_recipe_sideways.pdf"),
             [
                 ["Simply","Recipes", 'spinach'],
             ]),
         ]
 
-    #@pytest.mark.skipif(True, reason="Just testing")
+    # @pytest.mark.skipif(True, reason="Just testing")
     @pytest.mark.parametrize("dirname, tgt_folder, filename, expected", pdf_tests)
     def test_standalone(self, dirname, tgt_folder, filename, expected):
         """
@@ -107,7 +106,7 @@ class TestPydfocr:
         os.remove(out_filename)
         os.chdir(cwd)
 
-    #@pytest.mark.skipif(True, reason="just testing")
+    # @pytest.mark.skipif(True, reason="just testing")
     @pytest.mark.parametrize("dirname, tgt_folder, filename, expected", [pdf_tests[0]])
     def test_standalone_email(self, dirname, tgt_folder, filename, expected):
         """
@@ -181,11 +180,11 @@ class TestPydfocr:
 
         # Assert the smtp calls
         calls = [call(out_filename,
-                        os.path.abspath(os.path.join(tgt_folder,os.path.basename(out_filename))))]
+                      os.path.abspath(os.path.join(tgt_folder,os.path.basename(out_filename))))]
         if not "no_move_original" in config:
             new_file_name = os.path.basename(filename).replace(".pdf", "_2.pdf")
             calls.append(call(filename,
-                                os.path.abspath(os.path.join("temp","original", new_file_name))))
+                              os.path.abspath(os.path.join("test", "temp","original", new_file_name))))
         mock_move.assert_has_calls(calls)
 
     def test_set_binaries(self):

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -77,8 +77,8 @@ class TestPydfocr:
             if len(expected) > i:
                 for keyword in expected[i]:
                     assert(keyword in t)
-            print ("\n----------------------\nPage %d\n" % i)
-            print t
+            print("\n----------------------\nPage %d\n" % i)
+            print(t)
         os.remove(out_filename)
         os.chdir(cwd)
 
@@ -104,8 +104,8 @@ class TestPydfocr:
                 if len(expected) > i:
                     for keyword in expected[i]:
                         assert(keyword in t)
-                print ("\n----------------------\nPage %d\n" % i)
-                print t
+                print("\n----------------------\nPage %d\n" % i)
+                print(t)
             os.remove(out_filename)
             os.chdir(cwd)
             
@@ -146,8 +146,8 @@ class TestPydfocr:
             if len(expected) > i:
                 for keyword in expected[i]:
                     assert(keyword in t)
-            print ("\n----------------------\nPage %d\n" % i)
-            print t
+            print("\n----------------------\nPage %d\n" % i)
+            print(t)
         os.remove(out_filename)
         os.chdir(cwd)
         

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -1,5 +1,5 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr as P
+from pypdfocr import pypdfocr as P
 import pytest
 import os
 import logging

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -19,34 +19,63 @@ class TestPydfocr:
             logging.debug("pdf scanner found %d pages in %s" % (reader.getNumPages(), filename))
             for pgnum in range(reader.getNumPages()):
                 text = reader.getPage(pgnum).extractText()
-                text = text.encode('ascii', 'ignore')
+                # text = text.encode('ascii', 'ignore')
                 text = text.replace('\n', ' ')
                 yield text
-    
+
+    filepath = os.path.dirname(__file__)
     pdf_tests = [
-            (".", os.path.join("temp","target","recipe"), os.path.join("..","test", "pdfs", "test_recipe.pdf"), [ ["Simply Recipes"],
-                                 ]),
-        (".", os.path.join("temp","target","patents"), os.path.join("pdfs","test_patent.pdf"), [ 
-                           ["asynchronous", "subject to", "20 Claims"], # Page 1
-                           ["FOREIGN PATENT" ], # Page 2
-                            ]),
-        (".", os.path.join("temp","target", "default"), os.path.join("pdfs","test_sherlock.pdf"), [ ["Bohemia", "Trincomalee"], # Page 1
-                           ["hundreds of times" ], # Page 2
-                           ]),
-        ("pdfs", os.path.join("temp","target","default"), "test_sherlock.pdf", [ ["Bohemia", "Trincomalee"], # Page 1
-                           ["hundreds of times" ], # Page 2
-                           ]),
-            (".", os.path.join("temp","target","recipe"), os.path.join("..","test", "pdfs", "1.pdf"), [ ["Simply","Recipes"],
-                                 ]),
-            (".", os.path.join("temp","target","recipe"), os.path.join("..","test", "pdfs", "test_recipe_sideways.pdf"), [ ["Simply","Recipes", 'spinach'],
-                                 ]),
+        (
+            # Test the single file conversion with no filing.
+            filepath,
+            os.path.join(filepath, "temp","target","recipe"),
+            os.path.join(filepath, "pdfs", "test_recipe.pdf"),
+            [ ["Simply Recipes"],]),
+        (
+            filepath,
+            os.path.join("temp","target","patents"),
+            os.path.join("pdfs","test_patent.pdf"),
+            [
+                ["asynchronous", "subject to", "20 Claims"], # Page 1
+                ["FOREIGN PATENT" ], # Page 2
+                ]),
+        (
+            filepath,
+            os.path.join("temp","target", "default"),
+            os.path.join("pdfs","test_sherlock.pdf"),
+            [
+                ["Bohemia", "Trincomalee"], # Page 1
+                ["hundreds of times" ], # Page 2
+            ]),
+        (
+            os.path.join(filepath, "pdfs"),
+            os.path.join("temp","target","default"),
+            "test_sherlock.pdf",
+            [
+                ["Bohemia", "Trincomalee"], # Page 1
+                ["hundreds of times" ], # Page 2
+            ]),
+        (
+            filepath,
+            os.path.join("temp","target","recipe"),
+            os.path.join("..","test", "pdfs", "1.pdf"),
+            [
+                ["Simply","Recipes"],
+            ]),
+        (
+            filepath,
+            os.path.join("temp","target","recipe"),
+            os.path.join("..","test", "pdfs", "test_recipe_sideways.pdf"),
+            [
+                ["Simply","Recipes", 'spinach'],
+            ]),
         ]
 
     #@pytest.mark.skipif(True, reason="Just testing")
     @pytest.mark.parametrize("dirname, tgt_folder, filename, expected", pdf_tests)
     def test_standalone(self, dirname, tgt_folder, filename, expected):
         """
-            Test the single file conversion with no filing.  
+            Test the single file conversion with no filing.
             Tests relative paths (".."), files in subirs, and files in current dir
             Checks for that _ocr file is created and keywords found in pdf.
             Modify :attribute:`pdf_tests` for changing keywords, etc
@@ -57,9 +86,9 @@ class TestPydfocr:
 
         # First redo the unix-style paths, in case we're running on windows
         # Assume paths in unix-style
-        dirname = os.path.join(*(dirname.split("/")))
-        tgt_folder = os.path.join(*(tgt_folder.split("/")))
-        filename = os.path.join(*(filename.split("/")))
+        # dirname = os.path.join(*(dirname.split("/")))
+        # tgt_folder = os.path.join(*(tgt_folder.split("/")))
+        # filename = os.path.join(*(filename.split("/")))
 
 
         cwd = os.getcwd()
@@ -104,7 +133,7 @@ class TestPydfocr:
                 print(t)
             os.remove(out_filename)
             os.chdir(cwd)
-            
+
             # Assert the smtp calls
             instance = mock_smtp.return_value
             assert(instance.starttls.called)
@@ -112,7 +141,10 @@ class TestPydfocr:
             assert(instance.sendmail.called)
 
     @patch('shutil.move')
-    @pytest.mark.parametrize("config", [("test_pypdfocr_config.yaml"), ("test_pypdfocr_config_no_move_original.yaml")])
+    @pytest.mark.parametrize(
+        "config",
+        [(os.path.join(filepath, "test_pypdfocr_config.yaml")),
+         (os.path.join(filepath, "test_pypdfocr_config_no_move_original.yaml"))])
     @pytest.mark.parametrize("dirname, tgt_folder, filename, expected", pdf_tests[0:3])
     def test_standalone_filing(self, mock_move, config, dirname, tgt_folder, filename, expected):
         """
@@ -146,7 +178,7 @@ class TestPydfocr:
             print(t)
         os.remove(out_filename)
         os.chdir(cwd)
-        
+
         # Assert the smtp calls
         calls = [call(out_filename,
                         os.path.abspath(os.path.join(tgt_folder,os.path.basename(out_filename))))]

--- a/test/test_pypdfocr.py
+++ b/test/test_pypdfocr.py
@@ -5,11 +5,7 @@ import os
 import logging
 
 from PyPDF2 import PdfFileReader
-import smtplib
-from mock import Mock
 from mock import patch, call
-from mock import MagicMock
-from mock import PropertyMock
 
 
 class TestPydfocr:

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -1,5 +1,5 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_tesseract as P
+from pypdfocr import pypdfocr_tesseract as P
 import pytest
 import os
 

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -3,9 +3,7 @@ import pypdfocr.pypdfocr_tesseract as P
 import pytest
 import os
 
-import hashlib
-
-from mock import patch, call
+from mock import patch
 
 class TestTesseract:
 

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -70,7 +70,7 @@ class TestTesseract:
 
     def test_tesseract_version(self, capsys):
         p = P.PyTesseract({})
-        p.required = "100"
+        p.required = "100.01"
         with pytest.raises(SystemExit):
             p.make_hocr_from_pnms("")
         out, err = capsys.readouterr()

--- a/test/test_watcher.py
+++ b/test/test_watcher.py
@@ -1,15 +1,11 @@
-#from pypdfocr import PyPDFOCR as P
 import pypdfocr.pypdfocr_watcher as P
 import pytest
 
-import evernote.api.client
-import evernote.edam.type.ttypes as Types
-import hashlib
 import time
 import os
 from collections import namedtuple
 
-from mock import patch, call
+from mock import patch
 
 class TestWatching:
 

--- a/test/test_watcher.py
+++ b/test/test_watcher.py
@@ -19,20 +19,20 @@ class TestWatching:
 
     @patch('shutil.move')
     @pytest.mark.parametrize(("filename, expected"), filenames)
-    def test_rename(self, mock_move, filename, expected):
+    def test_rename(self, mock_move, filename, expected, tmpdir):
     
         if expected == None:
             expected = filename
 
-        p = P.PyPdfWatcher('temp',{})
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")),{})
 
         # First, test code that does not move original
         ret = p.rename_file_with_spaces(filename)
         assert (ret==expected)
 
-    def test_check_for_new_pdf(self):
+    def test_check_for_new_pdf(self, tmpdir):
     
-        p = P.PyPdfWatcher('temp', {})
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
         p.check_for_new_pdf("blah_ocr.pdf")
         assert("blah_ocr.pdf" not in p.events)
         p.check_for_new_pdf("blah.pdf")
@@ -45,8 +45,8 @@ class TestWatching:
         p.check_for_new_pdf("blah.pdf")
         assert(p.events['blah.pdf']-time.time() <=1) # Check that time stamp was updated
 
-    def test_events(self):
-        p = P.PyPdfWatcher('temp', {})
+    def test_events(self, tmpdir):
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
 
         event = namedtuple('event', 'src_path, dest_path')
 
@@ -59,8 +59,9 @@ class TestWatching:
         p.on_modified(event(src_path='temp_recipe3.pdf', dest_path=None))
         assert('temp_recipe3.pdf' in p.events)
 
-    def test_check_queue(self):
-        p = P.PyPdfWatcher('temp', {})
+    def test_check_queue(self, tmpdir):
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
+        assert p.events == {}
         now = time.time()
         p.events['blah.pdf'] = now
         f = p.check_queue()

--- a/test/test_watcher.py
+++ b/test/test_watcher.py
@@ -1,4 +1,4 @@
-import pypdfocr.pypdfocr_watcher as P
+from pypdfocr import pypdfocr_watcher as P
 import pytest
 
 import time


### PR DESCRIPTION
This is work-in-progress pull request for python 3 compatibility addressing issue #36.

The evernote package isn't currently available for py3 (see [https://pypi.python.org/pypi/evernote](https://pypi.python.org/pypi/evernote)), which causes a problem. For now all evernote functionality has been removed, including for py2 (hence why this is a WIP PR). There are a couple of options here:

  1. Use the beta evernote py3 SDK (https://github.com/evernote/evernote-sdk-python3)
  2. Remove everynote support completely
  3. Retain evernote in py2, but omit it in py3

Also fabric isn't compatible with py3 yet either. I haven't worked with it before, so am not sure how important it is to the dev workflow here. For now I've changed tests to run directly instead of via the fabric generated `runtests.py`.

p.s. Sorry it's so big - but it feels like an all-or-nothing situation. I've tried to keep it only to changes needed for py3 compatibility, and have endeavored to keep the functionality identical. Before this is merged I'll squash the commits so all my mistakes aren't included, but kept the individual commits for now to make reviewing easier.