### PR TITLE
Python 3 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get install -y tesseract-ocr ghostscript imagemagick
 install: 
-    - "pip install -r requirements.txt --use-mirrors"
-    - "pip install pytest mock --use-mirrors"
+    - "pip install -r requirements.txt"
+    - "pip install pytest mock"
     - "pip install ."
 script: 
-    - "python setup.py test"
+    - "pytest test"

--- a/pypdfocr/pypdfocr_filer_dirs.py
+++ b/pypdfocr/pypdfocr_filer_dirs.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 
-from pypdfocr_filer import PyFiler
+from .pypdfocr_filer import PyFiler
 
 """
     Implementation of a filer class 

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -19,17 +19,21 @@ import hashlib
 import time
 import sys
 
-from pypdfocr_filer import PyFiler
+from .pypdfocr_filer import PyFiler
 
 import functools
 
-from evernote.api.client import EvernoteClient
-import evernote.edam.type.ttypes as Types
-import evernote.edam.userstore.constants as UserStoreConstants
-from evernote.edam.error.ttypes import EDAMUserException
-from evernote.edam.error.ttypes import EDAMSystemException
-from evernote.edam.error.ttypes import EDAMNotFoundException
-from evernote.edam.error.ttypes import EDAMErrorCode
+try:
+    from evernote.api.client import EvernoteClient
+    import evernote.edam.type.ttypes as Types
+    import evernote.edam.userstore.constants as UserStoreConstants
+    from evernote.edam.error.ttypes import EDAMUserException
+    from evernote.edam.error.ttypes import EDAMSystemException
+    from evernote.edam.error.ttypes import EDAMNotFoundException
+    from evernote.edam.error.ttypes import EDAMErrorCode
+    ENABLED = True
+except ImportError:
+    ENABLED = False
 
 
 """

--- a/pypdfocr/pypdfocr_gs.py
+++ b/pypdfocr/pypdfocr_gs.py
@@ -92,21 +92,21 @@ class PyGs(object):
             listing = os.listdir('.')
 
             # Find all possible gs* sub-directories
-	    listing = [x for x in listing if x.startswith('gs')]
+            listing = [x for x in listing if x.startswith('gs')]
 
             # TODO: Make this a natural sort
             listing.sort(reverse=True)
-	    for bindir in listing:
-		binpath = os.path.join(bindir,'bin')
-		if not os.path.exists(binpath): continue
-		os.chdir(binpath)
+            for bindir in listing:
+                binpath = os.path.join(bindir,'bin')
+                if not os.path.exists(binpath): continue
+                os.chdir(binpath)
                 # Look for gswin64c.exe or gswin32c.exe (the c is for the command-line version)
-		gswin = glob.glob('gswin*c.exe')
-		if len(gswin) == 0:
-		    continue
-		gs = os.path.abspath(gswin[0]) # Just use the first found .exe (Do i need to do anything more complicated here?)
-		os.chdir(cwd)
-		return gs
+                gswin = glob.glob('gswin*c.exe')
+                if len(gswin) == 0:
+                    continue
+                gs = os.path.abspath(gswin[0]) # Just use the first found .exe (Do i need to do anything more complicated here?)
+                os.chdir(cwd)
+                return gs
 
         if not gs:
             error(self.msgs['GS_MISSING_BINARY'])
@@ -171,10 +171,10 @@ class PyGs(object):
         try:
             cmd = '%s -q -dNOPAUSE %s -sOutputFile="%s" "%s" -c quit' % (self.binary, options, output_filename, pdf_filename)
             logging.info(cmd)        
-            out = subprocess.check_output(cmd, shell=True)
+            out = subprocess.check_output(cmd, shell=True, universal_newlines=True)
 
         except subprocess.CalledProcessError as e:
-            print e.output
+            print(e.output)
             if "undefined in .getdeviceparams" in e.output:
                 error(self.msgs['GS_OUTDATED'])
             else:

--- a/pypdfocr/pypdfocr_multiprocessing.py
+++ b/pypdfocr/pypdfocr_multiprocessing.py
@@ -13,19 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, multiprocessing.forking
 import logging
+import os
+import sys
 
 """ Special work-around to support multiprocessing and pyinstaller --onefile on windows systms
 
     https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Multiprocessing
 """
+try:
+    # Python 3.4+
+    if sys.platform.startswith('win'):
+        import multiprocessing.popen_spawn_win32 as forking
+    else:
+        import multiprocessing.popen_fork as forking
+except ImportError:
+    import multiprocessing.forking as forking
 
-import multiprocessing.forking as forking
-import os
-import sys
 
-class _Popen(multiprocessing.forking.Popen):
+class _Popen(forking.Popen):
     def __init__(self, *args, **kw):
         if hasattr(sys, 'frozen'):
             # We have to set original _MEIPASS2 value from sys._MEIPASS

--- a/pypdfocr/pypdfocr_pdf.py
+++ b/pypdfocr/pypdfocr_pdf.py
@@ -31,7 +31,6 @@ import time
 import tempfile
 import glob
 
-import cStringIO
 import base64
 import zlib
 import math
@@ -52,7 +51,7 @@ from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT
 from reportlab.platypus.paragraph import Paragraph
 
-from pypdfocr_util import Retry
+from .pypdfocr_util import Retry
 from functools import partial
 
 class RotatedPara(Paragraph):
@@ -152,10 +151,11 @@ class PyPdf(object):
         all_text_filename = os.path.join(pdf_dir, "%s_text.pdf" % (basename))
         merger = PdfFileMerger()
         for text_pdf_filename in text_pdf_filenames:
-            merger.append(PdfFileReader(file(text_pdf_filename, 'rb')))
+            with open(text_pdf_filename, 'rb') as f:
+                merger.append(PdfFileReader(f))
         merger.write(all_text_filename)
         merger.close()
-	del merger
+        del merger
 
 
         writer = PdfFileWriter()

--- a/pypdfocr/pypdfocr_pdffiler.py
+++ b/pypdfocr/pypdfocr_pdffiler.py
@@ -18,15 +18,14 @@
     on keywords
 """
 
-from sets import Set    
 import sys, os
 import re
 import logging
 import shutil
 
 from PyPDF2 import PdfFileReader
-from pypdfocr_filer import PyFiler
-from pypdfocr_filer_dirs import PyFilerDirs
+from .pypdfocr_filer import PyFiler
+from .pypdfocr_filer_dirs import PyFilerDirs
 
 class PyPdfFiler(object):
     def __init__(self, filer):
@@ -36,7 +35,7 @@ class PyPdfFiler(object):
 
         # Whether to fall back on filename for matching keywords against
         # if there is no match in the text
-        self.file_using_filename = False 
+        self.file_using_filename = False
 
     def iter_pdf_page_text(self, filename):
         self.filename = filename
@@ -44,7 +43,7 @@ class PyPdfFiler(object):
         logging.info("pdf scanner found %d pages in %s" % (reader.getNumPages(), filename))
         for pgnum in range(reader.getNumPages()):
             text = reader.getPage(pgnum).extractText()
-            text = text.encode('ascii', 'ignore')
+            # text = text.encode('ascii', 'ignore')
             text = text.replace('\n', ' ')
             yield text
 
@@ -56,10 +55,10 @@ class PyPdfFiler(object):
                 if s in searchText:
                     logging.info("Matched keyword '%s'" % s)
                     return folder
-        # No match found, so return 
+        # No match found, so return
         return None
 
-    def file_original (self, original_filename):
+    def file_original(self, original_filename):
         return self.filer.file_original(original_filename)
 
     def move_to_matching_folder(self, filename):
@@ -72,9 +71,9 @@ class PyPdfFiler(object):
 
         tgt_file = self.filer.move_to_matching_folder(filename, tgt_folder)
         return tgt_file
-        
+
 if __name__ == '__main__':
     p = PyPdfFiler(PyFilerDirs())
     for page_text in p.iter_pdf_page_text("scan_ocr.pdf"):
-        print (page_text)
+        print(page_text)
 

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -28,7 +28,7 @@ import functools
 import signal
 
 from multiprocessing import Pool
-from pypdfocr_interrupts import init_worker
+from .pypdfocr_interrupts import init_worker
 
 # Ugly hack to pass in object method to the multiprocessing library
 # From http://www.rueckstiess.net/research/snippets/show/ca1d7d90
@@ -58,7 +58,7 @@ class PyPreprocess(object):
             logging.debug(out)
             return out
         except subprocess.CalledProcessError as e:
-            print e.output
+            print(e.output)
             self._warn("Could not run command %s" % cmd_list)
             
 
@@ -102,14 +102,14 @@ class PyPreprocess(object):
             logging.info("Starting preprocessing parallel execution")
             preprocessed_filenames = pool.map(unwrap_self,zip([self]*len(fns),fns))
             pool.close()
-        except KeyboardInterrupt or Exception:
+        except (KeyboardInterrupt, Exception):
             print("Caught keyboard interrupt... terminating")
             pool.terminate()
             #sys,exit(-1)
             raise
         finally:
             pool.join()
-            logging.info ("Completed preprocessing")
+            logging.info("Completed preprocessing")
 
         return preprocessed_filenames
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pillow>=2.2
 reportlab>=2.7
 watchdog>=0.6.0
 pypdf2>=1.23
-evernote
+evernote; python_version < '3'

--- a/test/test_gs.py
+++ b/test/test_gs.py
@@ -1,12 +1,9 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_gs as P
+from pypdfocr import pypdfocr_gs as P
 import pytest
 import os
 
-import hashlib
-
-from mock import patch, call
-from pytest import skip
+from mock import patch
 
 class TestGS:
 

--- a/test/test_option_parsing.py
+++ b/test/test_option_parsing.py
@@ -1,5 +1,7 @@
-#from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr as P
+import os
+import sys
+
+from pypdfocr import pypdfocr as P
 import pytest
 
 
@@ -37,11 +39,15 @@ class TestOptions:
             self.p.get_options(opts)
 
         # Assert that it checks that the config file is present
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         assert(self.p.enable_filing)
         assert(self.p.config)
 
+    @pytest.mark.skipif(sys.version_info.major>2,
+                        reason="Evernote disabled for py3")
     def test_standalone_filing_evernote(self):
         # Check when evernote is enabled
         opts = ["blah.pdf"]
@@ -50,7 +56,9 @@ class TestOptions:
         with pytest.raises(SystemExit):
             self.p.get_options(opts)
 
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         # Enabling -e should turn on filing too
         assert(self.p.enable_filing)
@@ -64,6 +72,21 @@ class TestOptions:
         assert(self.p.enable_evernote)
         assert(self.p.config)
         assert(not self.p.watch)
+
+    @pytest.mark.skipif(sys.version_info.major==2,
+                        reason="Evernote works on py2")
+    def test_evernote_disabled(self):
+        opts = ["blah.pdf"]
+        opts.append('-e')
+        # Assert that it checks that the config file is present
+        with pytest.raises(SystemExit):
+            self.p.get_options(opts)
+
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
+        self.p.get_options(opts)
+        assert not self.p.enable_evernote
 
     def test_standalone_watch_conflict(self):
         # When pdf file is specified, we don't want to allow watch option
@@ -80,23 +103,30 @@ class TestOptions:
         opts = ['-w temp']
         self.p.get_options(opts)
         assert(self.p.watch_dir)
-
-        opts.append('--config=test_option_config.yaml')
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts.append('--config={}'.format(conf_path))
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)
         assert(not self.p.enable_filing)
         assert(not self.p.enable_evernote)
 
+    @pytest.mark.skipif(sys.version_info.major>2,
+                        reason="Evernote disabled for py3")
     def test_watch_filing_evernote(self):
-        opts = ['-w temp', '-e', '--config=test_option_config.yaml']
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts = ['-w temp', '-e', '--config={}'.format(conf_path)]
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)
         assert(self.p.enable_filing)
         assert(self.p.enable_evernote)
 
-        opts = ['-w temp', '-f', '-e',  '--config=test_option_config.yaml']
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_option_config.yaml')
+        opts = ['-w temp', '-f', '-e',  '--config={}'.format(conf_path)]
         self.p.get_options(opts)
         assert(self.p.watch)
         assert(self.p.config)

--- a/test/test_pdf_filer.py
+++ b/test/test_pdf_filer.py
@@ -1,12 +1,8 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr as P
-import pytest
+from pypdfocr import pypdfocr as P
 import os
 
-import hashlib
-
 from mock import patch, call
-from pytest import skip
 
 class TestPDFFiler:
 
@@ -19,7 +15,9 @@ class TestPDFFiler:
         # Mock the move function so we don't actually end up filing
         p = P.PyPDFOCR()
         cwd = os.getcwd()
-        filename = os.path.join("pdfs", "test_super_long_keyword.pdf")
+        filename = os.path.join(os.path.dirname(__file__),
+                                "pdfs",
+                                "test_super_long_keyword.pdf")
         out_filename = filename.replace(".pdf", "_ocr.pdf")
 
         if os.path.exists(out_filename):
@@ -27,7 +25,10 @@ class TestPDFFiler:
 
         print("Current directory: %s" % os.getcwd())
         #opts = [filename, "--config=test_pypdfocr_config.yaml", "-f"]
-        opts = [filename, "--config=test_pypdfocr_config_filename.yaml", "-f", "-n"]
+        conf_path = os.path.join(
+            os.path.dirname(__file__), 'test_pypdfocr_config.yaml')
+
+        opts = [filename, "--config={}".format(conf_path), "-f", "-n"]
         p.go(opts)
 
         assert(os.path.exists(out_filename))
@@ -38,4 +39,4 @@ class TestPDFFiler:
 
 
 
-        
+

--- a/test/test_tesseract.py
+++ b/test/test_tesseract.py
@@ -1,11 +1,9 @@
 #from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_tesseract as P
+from pypdfocr import pypdfocr_tesseract as P
 import pytest
 import os
 
-import hashlib
-
-from mock import patch, call
+from mock import patch
 
 class TestTesseract:
 
@@ -72,7 +70,7 @@ class TestTesseract:
 
     def test_tesseract_version(self, capsys):
         p = P.PyTesseract({})
-        p.required = "100"
+        p.required = "100.01"
         with pytest.raises(SystemExit):
             p.make_hocr_from_pnms("")
         out, err = capsys.readouterr()

--- a/test/test_watcher.py
+++ b/test/test_watcher.py
@@ -1,15 +1,11 @@
-#from pypdfocr import PyPDFOCR as P
-import pypdfocr.pypdfocr_watcher as P
+from pypdfocr import pypdfocr_watcher as P
 import pytest
 
-import evernote.api.client
-import evernote.edam.type.ttypes as Types
-import hashlib
 import time
 import os
 from collections import namedtuple
 
-from mock import patch, call
+from mock import patch
 
 class TestWatching:
 
@@ -23,20 +19,20 @@ class TestWatching:
 
     @patch('shutil.move')
     @pytest.mark.parametrize(("filename, expected"), filenames)
-    def test_rename(self, mock_move, filename, expected):
+    def test_rename(self, mock_move, filename, expected, tmpdir):
     
         if expected == None:
             expected = filename
 
-        p = P.PyPdfWatcher('temp',{})
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")),{})
 
         # First, test code that does not move original
         ret = p.rename_file_with_spaces(filename)
         assert (ret==expected)
 
-    def test_check_for_new_pdf(self):
+    def test_check_for_new_pdf(self, tmpdir):
     
-        p = P.PyPdfWatcher('temp', {})
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
         p.check_for_new_pdf("blah_ocr.pdf")
         assert("blah_ocr.pdf" not in p.events)
         p.check_for_new_pdf("blah.pdf")
@@ -49,8 +45,8 @@ class TestWatching:
         p.check_for_new_pdf("blah.pdf")
         assert(p.events['blah.pdf']-time.time() <=1) # Check that time stamp was updated
 
-    def test_events(self):
-        p = P.PyPdfWatcher('temp', {})
+    def test_events(self, tmpdir):
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
 
         event = namedtuple('event', 'src_path, dest_path')
 
@@ -63,8 +59,9 @@ class TestWatching:
         p.on_modified(event(src_path='temp_recipe3.pdf', dest_path=None))
         assert('temp_recipe3.pdf' in p.events)
 
-    def test_check_queue(self):
-        p = P.PyPdfWatcher('temp', {})
+    def test_check_queue(self, tmpdir):
+        p = P.PyPdfWatcher(str(tmpdir.mkdir("tmp")), {})
+        assert p.events == {}
         now = time.time()
         p.events['blah.pdf'] = now
         f = p.check_queue()


### PR DESCRIPTION
This is an updated to PR #69, with commits squashed to present a cleaner history. It still addresses issue #36.

This updates to include compatibility with py3, whilst retaining
all functionality in py2.

The evernote library is not yet py3 compatible, so is not used in
the py3 version. It is however still retained when using py2.

Also fabric isn't compatible with py3 yet either. I haven't worked with it before, so am not sure how important it is to the dev workflow here. For now I've changed tests to run directly instead of via the fabric generated runtests.py.