### PR TITLE
Resolves ValueError for string representations of floats.

### DIFF
--- a/pypdfocr/pypdfocr_tesseract.py
+++ b/pypdfocr/pypdfocr_tesseract.py
@@ -95,8 +95,8 @@ class PyTesseract(object):
                     ver_str = ver_str[:-3]
 
         # Iterate through the version dots
-        ver = [int(x) for x in ver_str.split('.')]
-        req = [int(x) for x in self.required.split('.')]
+        ver = [int(float(x)) for x in ver_str.split('.')]
+        req = [int(float(x)) for x in self.required.split('.')]
 
         # Aargh, in windows 3.02.02 is reported as version 3.02  
         # SFKM


### PR DESCRIPTION
The following are totally acceptable in python:

*   passing a string representation of an integer into `int`
*   passing a string representation of a float into `float`
*   passing a string representation of an integer into `float`
*   passing a float into `int`
*   passing an integer into `float`

But you get a `ValueError` if you pass a string representation of a `float` into `int`, or a string representation of anything but an integer (including empty string).