### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ will happen in sub-directories under this directory.
 
 The ``folders`` section defines your filing directories and the keywords
 associated with them. In this example, we have three filing directories
-(finances, travl, receipts), and some associated keywords for each
+(finances, travel, receipts), and some associated keywords for each
 filing directory. For example, if your OCR'ed PDF contains the phrase
 "american express" (in any upper/lower case), it will be filed into
 ``docs/filed/finances``
@@ -250,7 +250,7 @@ PyPDFOCR is available in PyPI, so you can just run:
 
     pip install pypdfocr
 
-Please note that some of the 3rd-party libraries required by PyPDFOCR wiill
+Please note that some of the 3rd-party libraries required by PyPDFOCR will
 require some build tools, especially on a default Ubuntu system.  If you run
 into any issues using pip install, you may want to install the
 following packages on Ubuntu and try again:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,7 +313,7 @@ epub_copyright = u'2013, Author'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/pypdfocr/pypdfocr_filer_evernote.py
+++ b/pypdfocr/pypdfocr_filer_evernote.py
@@ -120,8 +120,8 @@ class PyFilerEvernote(PyFiler):
         """
             Establish a connection to evernote and authenticate.
 
-            :param dictUserInfo: Dict of user info like user/passwrod.  For now, just the dev token
-            :returns success: Return wheter connection succeeded
+            :param dictUserInfo: Dict of user info like user/password.  For now, just the dev token
+            :returns success: Return whether connection succeeded
             :rtype bool:
         """
         print("Authenticating to Evernote")

--- a/pypdfocr/pypdfocr_preprocess.py
+++ b/pypdfocr/pypdfocr_preprocess.py
@@ -84,7 +84,7 @@ class PyPreprocess(object):
                 '-blur 1x1',
                 #'-selective-blur 4x4+5%',
                 '-adaptive-sharpen 0x2',
-                '-negate -define morphology:compose=darken -morphology Thinning Rectangle:1x30+0+0 -negate ',  # Removes vertical lines >=60 pixes, reduces widht of >30 (oherwise tesseract < 3.03 completely ignores text close to vertical lines in a table)
+                '-negate -define morphology:compose=darken -morphology Thinning Rectangle:1x30+0+0 -negate ',  # Removes vertical lines >=60 pixes, reduces width of >30 (otherwise tesseract < 3.03 completely ignores text close to vertical lines in a table)
                 '"%s"' % (out_filename)
                 ]
         logging.info("Preprocessing image %s for better OCR" % in_filename)


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/conf.py
- pypdfocr/pypdfocr_filer_evernote.py
- pypdfocr/pypdfocr_preprocess.py

Fixes:
- Should read `will` rather than `wiill`.
- Should read `width` rather than `widht`.
- Should read `whether` rather than `wheter`.
- Should read `travel` rather than `travl`.
- Should read `that` rather than `shat`.
- Should read `password` rather than `passwrod`.
- Should read `otherwise` rather than `oherwise`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md